### PR TITLE
Apply dark theme and integrate Qt Designer UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ ECMCalCheck
 ===============
 
 This project includes a simple TCP client with a graphical user interface for
-displaying spectral data.  The GUI is implemented using **PyQt6** and requires
+displaying spectral data. The interface is loaded from a Qt Designer file and
+uses a dark themed palette.  The GUI is implemented using **PyQt6** and requires
 `PyQt6` and `matplotlib` to be installed.
 
 Run the client with:


### PR DESCRIPTION
## Summary
- load the Qt Designer file in `SpectroApp`
- apply a custom dark palette to the Qt application
- embed the Matplotlib canvas in the UI placeholder
- mention the dark theme in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867428979d0832f8f39ff867d540f38